### PR TITLE
v0.2.0 Simplify generic types, export mutative helpers

### DIFF
--- a/labs/demo-server/package.json
+++ b/labs/demo-server/package.json
@@ -31,8 +31,8 @@
     "start-win": "nodemon",
     "start-bin": "node bin/jrfs-demo-server.cjs",
     "test": "echo 'Sorry, no tests yet!'",
-    "watch": "tsc -w --noEmit --pretty --skipLibCheck --project tsconfig.eslint.json",
-    "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs ../../scripts/build-esm.mjs"
+    "watch": "node --watch-path=./src --watch-path=../../node_modules/@jrfs ../../scripts/build-esm.mjs",
+    "watch-ts": "tsc -w --noEmit --pretty --skipLibCheck --project tsconfig.eslint.json"
   },
   "nodemonConfig": {
     "delay": "250ms",

--- a/labs/demo-server/src/api/project/repo/fs.ts
+++ b/labs/demo-server/src/api/project/repo/fs.ts
@@ -1,4 +1,3 @@
-// import { apply } from "mutative";
 // Local
 import { Maybe, Tags, Type, Static, apiController, define } from "@/common/api";
 import { Entry, TransactionOutParams } from "@jrfs/node";

--- a/labs/demo-shared/package.json
+++ b/labs/demo-shared/package.json
@@ -27,7 +27,7 @@
     "lint-fix": "eslint . --ext .ts --fix",
     "lint-ts": "tsc --noEmit --pretty --project ./tsconfig.eslint.json",
     "rm-build": "shx rm -rf lib/*",
-    "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
+    "watch": "node --watch-path=./src --watch-path=../../node_modules/@jrfs ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
     "nanoid": "^5.0.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^20.14.8",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
         "@typescript-eslint/parser": "^7.11.0",
+        "chalk": "^5.3.0",
         "datauri-cli": "^4.1.0",
         "delay-cli": "^2.0.0",
         "esbuild": "^0.21.3",
@@ -123,17 +124,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "labs/demo-server/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "labs/demo-shared": {
@@ -3520,15 +3510,11 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -4796,6 +4782,22 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
@@ -6408,6 +6410,21 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jake/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jake/node_modules/minimatch": {
@@ -12357,7 +12374,7 @@
     },
     "packages/core": {
       "name": "@jrfs/core",
-      "version": "0.0.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "mutative": "1.0.11"
@@ -12371,19 +12388,19 @@
     },
     "packages/idb": {
       "name": "@jrfs/idb",
-      "version": "0.0.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@jrfs/core": "^0.0.4",
+        "@jrfs/core": "^0.2.0",
         "idb": "^8.0.0"
       }
     },
     "packages/node": {
       "name": "@jrfs/node",
-      "version": "0.0.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@jrfs/core": "^0.0.4"
+        "@jrfs/core": "^0.2.0"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -12391,10 +12408,10 @@
     },
     "packages/typebox": {
       "name": "@jrfs/typebox",
-      "version": "0.0.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@jrfs/core": "^0.0.4"
+        "@jrfs/core": "^0.2.0"
       },
       "devDependencies": {
         "@sinclair/typebox": "^0.33.7"
@@ -12405,18 +12422,18 @@
     },
     "packages/web": {
       "name": "@jrfs/web",
-      "version": "0.0.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@jrfs/core": "^0.0.4"
+        "@jrfs/core": "^0.2.0"
       }
     },
     "packages/ws": {
       "name": "@jrfs/ws",
-      "version": "0.0.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@jrfs/core": "^0.0.4"
+        "@jrfs/core": "^0.2.0"
       },
       "devDependencies": {
         "ws": "^8.18.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "lint-fix": "eslint . --ext .ts --fix",
     "lint-ts": "tsc --noEmit --pretty --project ./tsconfig.eslint.json",
     "rm-build": "shx rm -rf lib/*",
-    "watch-build": "node --watch-path=./src ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
+    "watch": "node --watch-path=./src ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
     "mutative": "1.0.11"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jrfs/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "JRFS core library.",
   "repository": "github:jrfso/jrfs",
   "homepage": "https://github.com/jrfso/jrfs/tree/master/packages/core",

--- a/packages/core/src/Driver.ts
+++ b/packages/core/src/Driver.ts
@@ -17,6 +17,10 @@ export abstract class Driver {
   #opened = false;
 
   constructor(props: DriverProps) {
+    // TODO: Create #fileTree in open() or when fileTree is set INTERNAL-ly.
+    // That way we can remove DriverProps.fileTree and then we can create
+    // FileSystem without callbacks AFTER the driver in Repository constructor.
+
     this.#fileTree = WritableFileTree[INTERNAL].create(
       props.fileTree,
       props.createShortId,

--- a/packages/core/src/Driver.ts
+++ b/packages/core/src/Driver.ts
@@ -3,7 +3,6 @@ import type {
   Entry,
   FileTree,
   FileTypeProvider,
-  FileTypes,
   MutativePatches,
 } from "@/index";
 import { type CreateShortIdFunction } from "@/helpers";
@@ -11,13 +10,13 @@ import { INTERNAL } from "@/internal/types";
 import { WritableFileTree } from "@/WritableFileTree";
 
 /** Base JRFS driver class. */
-export abstract class Driver<FT extends FileTypes<FT>> {
+export abstract class Driver {
   #fileTree: WritableFileTree;
-  #fileTypes: FileTypeProvider<FT>;
+  #fileTypes: FileTypeProvider<any>;
   /** `true` if {@link open}, `false` if {@link close}d */
   #opened = false;
 
-  constructor(props: DriverProps<FT>) {
+  constructor(props: DriverProps) {
     this.#fileTree = WritableFileTree[INTERNAL].create(
       props.fileTree,
       props.createShortId,
@@ -164,14 +163,11 @@ export interface TransactionParams {
 }
 
 /** Callback to create a driver. */
-export type DriverFactory = <FT extends FileTypes<FT>>(
-  props: DriverProps<FT>,
-  options: any,
-) => Driver<FT>;
+export type DriverFactory = (props: DriverProps, options: any) => Driver;
 
-export interface DriverProps<FT extends FileTypes<FT>> {
+export interface DriverProps {
   createShortId: CreateShortIdFunction;
-  fileTypes: FileTypeProvider<FT>;
+  fileTypes: FileTypeProvider<any>;
   fileTree: FileTree;
 }
 /**
@@ -187,9 +183,6 @@ export interface DriverTypeOptions {
   // e.g. ["fs"]: FsDriverOptions;
 }
 /** Interface to declare driver types onto. */
-export interface DriverTypes<
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  FT extends FileTypes<FT>,
-> {
+export interface DriverTypes {
   // e.g. ["fs"]: FsDriver;
 }

--- a/packages/core/src/FileSystem.ts
+++ b/packages/core/src/FileSystem.ts
@@ -8,7 +8,7 @@ import {
   type NodeInfo,
 } from "@/types";
 import { applyPatch, createPatchProxy } from "@/helpers";
-import { INTERNAL, isDirectoryNode } from "@/internal/types";
+import { isDirectoryNode } from "@/internal/types";
 import type { Driver, TransactionOutParams } from "@/Driver";
 import { FileTree } from "@/FileTree";
 import { FileTypeProvider } from "@/FileTypeProvider";
@@ -32,35 +32,13 @@ export class FileSystem<FT extends FileTypes<FT>> extends FileTree {
   #driver = null! as Driver;
   #fileTypes: FileTypeProvider<FT>;
 
-  private constructor(options: { fileTypes: FileTypeProvider<FT> }) {
+  constructor(props: { driver: Driver; fileTypes: FileTypeProvider<FT> }) {
     super();
-    const { fileTypes } = options;
+    const { driver, fileTypes } = props;
+    this.#driver = driver;
     this.#fileTypes = fileTypes;
   }
 
-  // #region -- Internal
-  static #internal = {
-    create<FT extends FileTypes<FT>>(options: {
-      fileTypes: FileTypeProvider<FT>;
-      callbacks: {
-        setDriver: (value: Driver) => void;
-      };
-    }) {
-      const { fileTypes, callbacks } = options;
-      const fs = new FileSystem<FT>({
-        fileTypes,
-      });
-      callbacks.setDriver = (value: Driver) => {
-        fs.#driver = value;
-        (fs as any)[Symbol.toStringTag] = `FileSystem(${value})`;
-      };
-      return fs;
-    },
-  };
-  static get [INTERNAL]() {
-    return FileSystem.#internal;
-  }
-  // #endregion
   // #region -- Props
 
   get fileTypes() {

--- a/packages/core/src/FileSystem.ts
+++ b/packages/core/src/FileSystem.ts
@@ -275,11 +275,13 @@ export class FileSystem<FT extends FileTypes<FT>> extends FileTree {
       origData = (await this.get(toEntry)).data as D;
     }
     if (typeof writerOrData === "function") {
-      const writer = writerOrData;
-      const [data, patches, undo] = await createPatch(
-        origData,
-        writer as (data: unknown) => D | Promise<D> | void | Promise<void>,
-      );
+      // We don't need mutative's Draft<D> here to remove readonly from D's
+      // properties since D represents a mutable type already.
+      const writer = writerOrData as (
+        // data: Draft<T> is default, but for local cast skip the type import.
+        data: unknown,
+      ) => D | Promise<D> | void | Promise<void>;
+      const [data, patches, undo] = await createPatch(origData, writer);
       if (patches.length < 1) {
         // No change.
         return toEntry;

--- a/packages/core/src/FileSystem.ts
+++ b/packages/core/src/FileSystem.ts
@@ -1,4 +1,3 @@
-import { apply, create as createDataProxy } from "mutative";
 // Local
 import {
   type Entry,
@@ -8,6 +7,7 @@ import {
   type MutativePatches,
   type NodeInfo,
 } from "@/types";
+import { applyPatch, createPatchProxy } from "@/helpers";
 import { INTERNAL, isDirectoryNode } from "@/internal/types";
 import type { Driver, TransactionOutParams } from "@/Driver";
 import { FileTree } from "@/FileTree";
@@ -212,7 +212,7 @@ export class FileSystem<FT extends FileTypes<FT>> extends FileTree {
       // caller can handle it.
       throw new Error(`Entry cannot be patched "${to}".`);
     }
-    const data = apply(origData, patches);
+    const data = applyPatch(origData, patches);
     return this.#driver.write(
       {
         to,
@@ -294,7 +294,7 @@ export class FileSystem<FT extends FileTypes<FT>> extends FileTree {
     }
     if (typeof writerOrData === "function") {
       const writer = writerOrData;
-      const [draft, finalizeDraft] = createDataProxy(origData, {
+      const [draft, finalizeDraft] = createPatchProxy(origData, {
         enablePatches: true,
       });
       // CONSIDER: We can also let the writer return the whole data to write.

--- a/packages/core/src/FileSystem.ts
+++ b/packages/core/src/FileSystem.ts
@@ -20,6 +20,8 @@ import { FileTypeProvider } from "@/FileTypeProvider";
 // CONSIDER: Misc transactions...
 // - appendFile (could be good for letting client write a text log?)
 
+// TODO: A method to get a download url for any file.
+
 // TODO: Add a `realpath` type method in the FileSystem class.
 // - On the client, it should return the full real FS path from the server.
 // - On the server, it should return the full real FS path.

--- a/packages/core/src/FileSystem.ts
+++ b/packages/core/src/FileSystem.ts
@@ -27,13 +27,9 @@ import { FileTypeProvider } from "@/FileTypeProvider";
 /**
  * The top level file tree interface provided by a Repository.
  * @template FT File Types interface, to map file type names to TS types.
- * Each key should be registered via {@link fileTypes} later.
- * Each value must be in the shape of a `FileOf<Instance, Meta?>` type.
- * @template DK Driver key used in constructor option.
- * @template DT Driver type from `DriverTypes<FT>[DK]` else `Driver<FT>`.
  */
 export class FileSystem<FT extends FileTypes<FT>> extends FileTree {
-  #driver = null! as Driver<FT>;
+  #driver = null! as Driver;
   #fileTypes: FileTypeProvider<FT>;
 
   private constructor(options: { fileTypes: FileTypeProvider<FT> }) {
@@ -47,14 +43,14 @@ export class FileSystem<FT extends FileTypes<FT>> extends FileTree {
     create<FT extends FileTypes<FT>>(options: {
       fileTypes: FileTypeProvider<FT>;
       callbacks: {
-        setDriver: (value: Driver<FT>) => void;
+        setDriver: (value: Driver) => void;
       };
     }) {
       const { fileTypes, callbacks } = options;
       const fs = new FileSystem<FT>({
         fileTypes,
       });
-      callbacks.setDriver = (value: Driver<FT>) => {
+      callbacks.setDriver = (value: Driver) => {
         fs.#driver = value;
         (fs as any)[Symbol.toStringTag] = `FileSystem(${value})`;
       };

--- a/packages/core/src/Repository.ts
+++ b/packages/core/src/Repository.ts
@@ -30,7 +30,7 @@ export class Repository<
     : Driver<FT>,
 > {
   #driver: Driver<FT>;
-  #fs: FileSystem<FT, DK>;
+  #fs: FileSystem<FT>;
 
   constructor(
     options: RepositoryOptions<FT, DK> & Partial<Pick<DriverTypeOptions, DK>>,
@@ -41,7 +41,7 @@ export class Repository<
       createShortId = defaultCreateShortId,
     } = options;
     const callbacks = {} as { setDriver(value: Driver<FT>): void };
-    const fs = FileSystem[INTERNAL].create<FT, DK>({
+    const fs = FileSystem[INTERNAL].create<FT>({
       fileTypes,
       callbacks,
     });

--- a/packages/core/src/Repository.ts
+++ b/packages/core/src/Repository.ts
@@ -1,6 +1,5 @@
 // Local
 import type { FileTypes } from "@/types";
-import { INTERNAL } from "@/internal/types";
 import type {
   Driver,
   DriverFactory,
@@ -38,22 +37,19 @@ export class Repository<
       fileTypes,
       createShortId = defaultCreateShortId,
     } = options;
-    const callbacks = {} as { setDriver(value: Driver): void };
-    const fs = FileSystem[INTERNAL].create<FT>({
-      fileTypes,
-      callbacks,
-    });
     const driverFactory = getDriverFactory(driverType);
     const driverOptions = options[driverType];
     const driver = driverFactory(
       {
         createShortId,
-        fileTree: fs,
         fileTypes,
       },
       driverOptions,
     );
-    callbacks.setDriver(driver);
+    const fs = new FileSystem<FT>({
+      driver,
+      fileTypes,
+    });
     this.#driver = driver;
     this.#fs = fs;
     // Set object name for the default `toString` implementation.
@@ -79,7 +75,7 @@ export class Repository<
    * Loads all directories and files within the repo path.
    */
   async open() {
-    return this.#driver.open();
+    return this.#driver.open(this.#fs);
   }
   // #endregion
   // #region -- Diagnostics

--- a/packages/core/src/Repository.ts
+++ b/packages/core/src/Repository.ts
@@ -20,16 +20,14 @@ import {
  * Each key should be registered via {@link FileTypeProvider} later.
  * Each value must be in the shape of a `FileOf<Instance, Meta?>` type.
  * @template DK Driver key used in constructor option.
- * @template DT Driver type from `DriverTypes<FT>[DK]` else `Driver<FT>`.
+ * @template DT Driver type from `DriverTypes[DK]` else `Driver`.
  */
 export class Repository<
   FT extends FileTypes<FT>,
-  DK extends keyof DriverTypes<FT> & string = keyof DriverTypes<FT>,
-  DT extends Driver<FT> = DriverTypes<FT>[DK] extends Driver<FT>
-    ? DriverTypes<FT>[DK]
-    : Driver<FT>,
+  DK extends keyof DriverTypes & string = keyof DriverTypes,
+  DT extends Driver = DriverTypes[DK] extends Driver ? DriverTypes[DK] : Driver,
 > {
-  #driver: Driver<FT>;
+  #driver: Driver;
   #fs: FileSystem<FT>;
 
   constructor(
@@ -40,14 +38,14 @@ export class Repository<
       fileTypes,
       createShortId = defaultCreateShortId,
     } = options;
-    const callbacks = {} as { setDriver(value: Driver<FT>): void };
+    const callbacks = {} as { setDriver(value: Driver): void };
     const fs = FileSystem[INTERNAL].create<FT>({
       fileTypes,
       callbacks,
     });
     const driverFactory = getDriverFactory(driverType);
     const driverOptions = options[driverType];
-    const driver = driverFactory<FT>(
+    const driver = driverFactory(
       {
         createShortId,
         fileTree: fs,
@@ -97,7 +95,7 @@ export class Repository<
 /** Options to create a {@link Repository}. */
 export interface RepositoryOptions<
   FT extends FileTypes<FT>,
-  DK extends keyof DriverTypes<FT> & string = keyof DriverTypes<FT>,
+  DK extends keyof DriverTypes & string = keyof DriverTypes,
 > {
   /** Name of the driver type to use. */
   driver: DK;
@@ -110,7 +108,7 @@ export interface RepositoryOptions<
 const driverFactories: Record<string, DriverFactory> = {};
 
 export function getDriverFactory<FT extends FileTypes<FT>>(
-  driverType: keyof DriverTypes<FT> & string,
+  driverType: keyof DriverTypes & string,
 ) {
   const driverFactory = driverFactories[driverType];
   if (!driverFactory) {
@@ -124,7 +122,7 @@ export function getDriverFactory<FT extends FileTypes<FT>>(
  * @param name Driver to register. Also see the TS declaration example below.
  * @param factory Function to create the driver instance.
  */
-export function registerDriver<K extends string = keyof DriverTypes<any>>(
+export function registerDriver<K extends string = keyof DriverTypes>(
   name: K,
   factory: DriverFactory,
 ) {

--- a/packages/core/src/WritableFileTree.ts
+++ b/packages/core/src/WritableFileTree.ts
@@ -1,6 +1,5 @@
-import { apply } from "mutative";
 // Local
-import { type CreateShortIdFunction, deepFreeze } from "@/helpers";
+import { type CreateShortIdFunction, applyPatch, deepFreeze } from "@/helpers";
 import {
   Node,
   INTERNAL,
@@ -689,7 +688,7 @@ export class WritableFileTree extends FileTree {
             } else {
               // Patch away since the original patch ctime matches our ctime.
               dataProps = {
-                data: apply(node.data, patch.patches),
+                data: applyPatch(node.data, patch.patches),
               };
             }
           }

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,3 +1,7 @@
+import { apply as applyPatch, create as createPatchProxy } from "mutative";
+
+export { applyPatch, createPatchProxy };
+
 const ALPHANUMLOWER = "0123456789abcdefghijklmnopqrstuvwxyz";
 
 /**

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,6 +1,47 @@
-import { apply as applyPatch, create as createPatchProxy } from "mutative";
+import { apply as applyPatch, rawReturn, makeCreator } from "mutative";
 
-export { applyPatch, createPatchProxy };
+// #region Mutative
+
+export { applyPatch, rawReturn };
+/**
+ * Creates patches to apply to a JS object. Creates new state from a base state.
+ *
+ * See [mutative.js](https://mutative.js.org/docs/api-reference/create)
+ *
+ * ```ts
+ * createPatch(baseState,
+ *   (draft) => unknown | Promise<unknown>
+ * ) => unknown | Promise<unknown>;
+ * ```
+ *
+ * ## Example
+ *
+ * ```ts
+ * import { createPatch, rawReturn } from '@jrfs/core';
+ *
+ * const baseState = { foo: { bar: 'str' }, arr: [] };
+ * const state = create(
+ *   baseState,
+ *   (draft) => {
+ *     draft.foo.bar = 'str2';
+ *     // or return { ...draft, foo:{bar:'str2'} };
+ *     // or return rawReturn({ foo:{bar:'str2'}, arr:[] });
+ *   },
+ * );
+ *
+ * expect(state).toEqual({ foo: { bar: 'str2' }, arr: [] });
+ * expect(state).not.toBe(baseState);
+ * expect(state.foo).not.toBe(baseState.foo);
+ * expect(state.arr).toBe(baseState.arr);
+ * ```
+ */
+export const createPatch = makeCreator({
+  enableAutoFreeze: true,
+  enablePatches: true,
+  strict: process.env.NODE_ENV === "development",
+});
+// #endregion
+// #region createShortId
 
 const ALPHANUMLOWER = "0123456789abcdefghijklmnopqrstuvwxyz";
 
@@ -26,6 +67,8 @@ export function createShortId(length: number = 9): string {
   return id;
 }
 export type CreateShortIdFunction = typeof createShortId;
+
+// #endregion
 
 /**
  * Deep `Object.freeze()`, works with Map and Set. From

--- a/packages/idb/package.json
+++ b/packages/idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jrfs/idb",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "JRFS idb file cache.",
   "repository": "github:jrfso/jrfs",
   "homepage": "https://github.com/jrfso/jrfs/tree/master/packages/idb",
@@ -36,7 +36,7 @@
     "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
-    "@jrfs/core": "^0.1.0",
+    "@jrfs/core": "^0.2.0",
     "idb": "^8.0.0"
   }
 }

--- a/packages/idb/package.json
+++ b/packages/idb/package.json
@@ -33,7 +33,7 @@
     "lint-fix": "eslint . --ext .ts --fix",
     "lint-ts": "tsc --noEmit --pretty --project ./tsconfig.eslint.json",
     "rm-build": "shx rm -rf lib/*",
-    "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
+    "watch": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
     "@jrfs/core": "^0.2.0",

--- a/packages/idb/src/FileCache.ts
+++ b/packages/idb/src/FileCache.ts
@@ -12,10 +12,10 @@ import {
   type FileDataChange,
   type FileTree,
   type FileTreeChange,
+  applyPatch,
   isFileId,
 } from "@jrfs/core";
 import type { FileCacheProvider } from "@jrfs/core/cache";
-import { apply } from "mutative";
 
 export interface IdbFileCacheOptions {
   db?: string;
@@ -116,8 +116,7 @@ export function createFileCache(options: IdbFileCacheOptions = {}) {
           return;
         }
         console.log(`[IDB] onTreeChange`, id, ctime, "(SET)");
-        // TODO: Don't make me import `apply` from "mutative".
-        const data = apply(cached.data, patch.patches);
+        const data = applyPatch(cached.data, patch.patches);
         await trx.store.put({ ctime, data } satisfies FileCacheItem, id);
       }
     }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jrfs/node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "JRFS Node drivers.",
   "repository": "github:jrfso/jrfs",
   "homepage": "https://github.com/jrfso/jrfs/tree/master/packages/node",
@@ -38,6 +38,6 @@
     "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
-    "@jrfs/core": "^0.1.0"
+    "@jrfs/core": "^0.2.0"
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,7 +35,7 @@
     "lint-fix": "eslint . --ext .ts --fix",
     "lint-ts": "tsc --noEmit --pretty --project ./tsconfig.eslint.json",
     "rm-build": "shx rm -rf lib/*",
-    "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
+    "watch": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
     "@jrfs/core": "^0.2.0"

--- a/packages/node/src/FsDriver.ts
+++ b/packages/node/src/FsDriver.ts
@@ -269,7 +269,7 @@ export class FsDriver<FT extends FileTypes<FT>> extends Driver<FT> {
   ): Promise<Entry> {
     return this.#transaction(async () => {
       const { to, data } = params;
-      // TODO: Better isDir/isFile detection!
+      // CONSIDER: Do we need isDir/isFile signaling for the caller here?
       const isDir = !("data" in params);
       const toPath = this.#fullPath(to);
       console.log("[FS] add", to);

--- a/packages/node/src/FsDriver.ts
+++ b/packages/node/src/FsDriver.ts
@@ -18,8 +18,8 @@ import {
 import { FsConfig, FsIndexData, FsIndexDefaultFileExtension } from "./types";
 
 declare module "@jrfs/core" {
-  interface DriverTypes<FT extends FileTypes<FT>> {
-    fs: FsDriver<FT>;
+  interface DriverTypes {
+    fs: FsDriver;
   }
   interface DriverTypeOptions {
     /** An absolute config file path or fs config options. */
@@ -35,7 +35,7 @@ export interface FsDriverOptions extends Partial<FsConfig> {
 // CONSIDER: Save tx in order to sync between restarts! Apply it inside onOpen
 // in the fileTree.build() block by setting files.tx = txFromFile;
 
-export class FsDriver<FT extends FileTypes<FT>> extends Driver<FT> {
+export class FsDriver extends Driver {
   /** The repo configuration. */
   #config: FsConfig;
   /** Full path to the config file, if any. */
@@ -50,7 +50,7 @@ export class FsDriver<FT extends FileTypes<FT>> extends Driver<FT> {
   #transactions: Transactions = { queue: [] };
 
   constructor(
-    props: DriverProps<FT>,
+    props: DriverProps,
     optionsOrConfigPath: string | FsDriverOptions,
   ) {
     const { config, configFile, rootPath, indexFile } =
@@ -385,10 +385,10 @@ export class FsDriver<FT extends FileTypes<FT>> extends Driver<FT> {
 (FsDriver as any)[Symbol.toStringTag] = "FsDriver";
 
 function createFsDriver<FT extends FileTypes<FT>>(
-  props: DriverProps<FT>,
+  props: DriverProps,
   optionsOrConfigPath: string | FsDriverOptions,
-): FsDriver<FT> {
-  return new FsDriver<FT>(props, optionsOrConfigPath);
+): FsDriver {
+  return new FsDriver(props, optionsOrConfigPath);
 }
 registerDriver("fs", createFsDriver);
 

--- a/packages/typebox/package.json
+++ b/packages/typebox/package.json
@@ -33,7 +33,7 @@
     "lint-fix": "eslint . --ext .ts --fix",
     "lint-ts": "tsc --noEmit --pretty --project ./tsconfig.eslint.json",
     "rm-build": "shx rm -rf lib/*",
-    "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
+    "watch": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
     "@jrfs/core": "^0.2.0"

--- a/packages/typebox/package.json
+++ b/packages/typebox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jrfs/typebox",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "JRFS TypeBox integration.",
   "repository": "github:jrfso/jrfs",
   "homepage": "https://github.com/jrfso/jrfs/tree/master/packages/typebox",
@@ -36,7 +36,7 @@
     "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
-    "@jrfs/core": "^0.1.0"
+    "@jrfs/core": "^0.2.0"
   },
   "devDependencies": {
     "@sinclair/typebox": "^0.33.7"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jrfs/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "JRFS browser drivers.",
   "repository": "github:jrfso/jrfs",
   "homepage": "https://github.com/jrfso/jrfs/tree/master/packages/web",
@@ -35,6 +35,6 @@
     "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
-    "@jrfs/core": "^0.1.0"
+    "@jrfs/core": "^0.2.0"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,7 +32,7 @@
     "lint-fix": "eslint . --ext .ts --fix",
     "lint-ts": "tsc --noEmit --pretty --project ./tsconfig.eslint.json",
     "rm-build": "shx rm -rf lib/*",
-    "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
+    "watch": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
     "@jrfs/core": "^0.2.0"

--- a/packages/web/src/WebDriver.ts
+++ b/packages/web/src/WebDriver.ts
@@ -1,12 +1,12 @@
 import {
+  type DriverProps,
+  type Entry,
+  type FileTree,
+  type FileTypes,
+  type TransactionOutParams,
+  type TransactionParams,
   Driver,
-  Entry,
-  FileTypes,
-  // Node,
-  TransactionParams,
-  DriverProps,
   registerDriver,
-  TransactionOutParams,
 } from "@jrfs/core";
 import { FileCacheProvider } from "@jrfs/core/cache";
 // Local
@@ -162,7 +162,7 @@ function createWebDriver<FT extends FileTypes<FT>>(
 registerDriver("web", createWebDriver);
 
 async function fsAction(
-  tree: DriverProps["fileTree"],
+  tree: FileTree,
   action: Promise<{ id: string; tx: number }>,
   out?: TransactionOutParams,
 ): Promise<Entry> {

--- a/packages/web/src/WebDriver.ts
+++ b/packages/web/src/WebDriver.ts
@@ -16,17 +16,17 @@ declare module "@jrfs/core" {
   interface DriverTypeOptions {
     web: WebDriverConfig;
   }
-  interface DriverTypes<FT extends FileTypes<FT>> {
-    web: WebDriver<FT>;
+  interface DriverTypes {
+    web: WebDriver;
   }
 }
 
-export class WebDriver<FT extends FileTypes<FT>> extends Driver<FT> {
+export class WebDriver extends Driver {
   /** The repo configuration. */
   #client: WebClient;
   #cache: FileCacheProvider | undefined;
 
-  constructor(props: DriverProps<FT>, config: WebDriverConfig) {
+  constructor(props: DriverProps, config: WebDriverConfig) {
     super(props);
     // Set object name for the default `toString` implementation.
     (this as any)[Symbol.toStringTag] = `WebDriver`;
@@ -154,15 +154,15 @@ export interface WebDriverConfig {
 (WebDriver as any)[Symbol.toStringTag] = "WebDriver";
 
 function createWebDriver<FT extends FileTypes<FT>>(
-  props: DriverProps<FT>,
+  props: DriverProps,
   config: WebDriverConfig,
-): WebDriver<FT> {
-  return new WebDriver<FT>(props, config);
+): WebDriver {
+  return new WebDriver(props, config);
 }
 registerDriver("web", createWebDriver);
 
 async function fsAction(
-  tree: DriverProps<any>["fileTree"],
+  tree: DriverProps["fileTree"],
   action: Promise<{ id: string; tx: number }>,
   out?: TransactionOutParams,
 ): Promise<Entry> {

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -33,7 +33,7 @@
     "lint-fix": "eslint . --ext .ts --fix",
     "lint-ts": "tsc --noEmit --pretty --project ./tsconfig.eslint.json",
     "rm-build": "shx rm -rf lib/*",
-    "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
+    "watch": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
     "@jrfs/core": "^0.2.0"

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jrfs/ws",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "JRFS ws integration.",
   "repository": "github:jrfso/jrfs",
   "homepage": "https://github.com/jrfso/jrfs/tree/master/packages/ws",
@@ -36,7 +36,7 @@
     "watch-build": "node --watch-path=./src --watch-path=../../node_modules/@jrfs/core/lib ../../scripts/build-esm.mjs lib --tsconfig tsconfig.prod.json"
   },
   "dependencies": {
-    "@jrfs/core": "^0.1.0"
+    "@jrfs/core": "^0.2.0"
   },
   "devDependencies": {
     "ws": "^8.18.0"


### PR DESCRIPTION
## Summary

- Simplifies `FileSystem` generic signature and remove unnecessary `driver` property.
- Simplifies `Driver` types, make them non-generic. Drivers that need typed `fileTypes` can cast to that type.
- Re-exports commonly used `mutative` helpers for use with integrations (`applyPatch`, `createPatch`).
  - Implement `createPatch` via mutative's `makeCreator`, allowing `FileSystem.write()` callbacks to return whole file data.
- Removes `DriverProps.fileTree` constructor argument to allow creating `Repository.fs` after driver. Replaces wonky `FileSystem` factory with a standard constructor.
